### PR TITLE
Lab2 - Allow Egress to specified domains

### DIFF
--- a/dcf/main.tf
+++ b/dcf/main.tf
@@ -1,5 +1,10 @@
 locals {
-  allowed_https_domains = []
+  allowed_https_domains = [
+    "aviatrix.com",
+    "*.amazonaws.com",
+    "cloud.google.com",
+    "*.microsoft.com"
+  ]
 }
 
 resource "aviatrix_web_group" "allow_internet_https" {


### PR DESCRIPTION
## Description

My applications need access to the following domains:

```    
"aviatrix.com",
"*.amazonaws.com",
"cloud.google.com",
"*.microsoft.com"
```
